### PR TITLE
Fix asOf initialization with timezone-aware date

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,7 +127,11 @@ export default function App() {
   const [panelOpen, setPanelOpen] = useState(false)
 
   const [term, setTerm] = useState('')
-  const [asOf, setAsOf] = useState('')
+  const [asOf, setAsOf] = useState(() => {
+    const d = new Date()
+    d.setMinutes(d.getMinutes() - d.getTimezoneOffset())
+    return d.toISOString().slice(0, 10)
+  })
   const [rows, setRows] = useState<KyFeatureProps[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)


### PR DESCRIPTION
## Summary
- initialize `asOf` state with current date adjusted for timezone

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899701a40b88327b98d880742c4508d