### PR TITLE
fix: handle pointer events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -257,7 +257,7 @@ export default function App() {
     closePopup()
   }
 
-  const handleMapClick = useCallback(async (evt: MapBrowserEvent<MouseEvent>) => {
+  const handleMapClick = useCallback(async (evt: MapBrowserEvent<PointerEvent>) => {
     const [x, y] = evt.coordinate as [number, number]
     closePopup()
     try {
@@ -363,12 +363,11 @@ export default function App() {
   useEffect(() => {
     const map = mapRef.current
     if (!map) return
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const handleDrag = (e: MapBrowserEvent<PointerEvent>) => closePopup()
-    map.on('singleclick', handleMapClick)
+    const handleDrag = () => closePopup()
+    map.on('singleclick', handleMapClick as unknown as (e: MapBrowserEvent<MouseEvent>) => void)
     map.on('pointerdrag', handleDrag)
     return () => {
-      map.un('singleclick', handleMapClick)
+      map.un('singleclick', handleMapClick as unknown as (e: MapBrowserEvent<MouseEvent>) => void)
       map.un('pointerdrag', handleDrag)
     }
   }, [handleMapClick, closePopup])


### PR DESCRIPTION
## Summary
- use PointerEvent for map click handler
- ignore drag event parameter and use handler directly
- cast click handler to satisfy singleclick listener types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cad11fc48832798e8013315f9a1f9